### PR TITLE
Fix negate of list objects

### DIFF
--- a/jsonmask_ng/mask.py
+++ b/jsonmask_ng/mask.py
@@ -46,7 +46,7 @@ def apply_json_mask(data, json_mask, is_negated=False, depth=1, max_depth=None):
                     apply_json_mask(
                         entry,
                         next_json_mask,
-                        is_negated=is_negated,
+                        is_negated=is_negated if key in json_mask else False,
                         depth=depth + 1,
                         max_depth=max_depth,
                     )

--- a/jsonmask_ng/tests/test_mask.py
+++ b/jsonmask_ng/tests/test_mask.py
@@ -39,6 +39,8 @@ def test_apply_json_mask():
          'a': [{'b': 1}]}, {'a': [{'c': [1, 2, 3]}]},),
         ({'a': [{'b': 1, 'c': [{'d': 1}, {'d': 2, 'e': 3}]}]}, 'a(c(e))', {
          'a': [{'c': [{}, {'e': 3}]}]}, {'a': [{'b': 1, 'c': [{'d': 1}, {'d': 2}]}]},),
+        ({'k1': [{'k1k1': 1, 'k1k2': 2}], 'k2': [{'k2k1': 2},{'k2k1': 3}]}, 'k1(k1k1)', {
+         'k1': [{'k1k1': 1}]}, {'k1': [{'k1k2': 2}], 'k2': [{'k2k1': 2},{'k2k1': 3}]},),
     ]
 
     for index, (data, _mask, expected_result, expected_result_when_negated,) in enumerate(tests, start=1):


### PR DESCRIPTION
When trying to use the is_negate field it will also negate list objects that arent supposed to be negated. This is due to the fact that we were setting is_negated even if the key wasnt in the json_mask. This PR is to fix this by only accepting is_negated field if the key is in the mask.
Testing
![Screen Shot 2023-10-11 at 11 12 22](https://github.com/juanyque/jsonmask_ng/assets/101218846/9933d799-3c93-4a64-bda5-3debb5d80a6d)
